### PR TITLE
Add DotEnvParser

### DIFF
--- a/DotEnvFile/DotEnvParser
+++ b/DotEnvFile/DotEnvParser
@@ -1,0 +1,26 @@
+using System.Collections.Specialized;
+using System.Text.RegularExpressions;
+
+namespace DotEnvFile
+{
+    public static class DotEnvParser
+    {
+        private const string ParserRegexPattern = "^([^\\s=]+)\\s*=\\s*(.+)$";
+        private static readonly Regex Parser = new Regex(ParserRegexPattern, RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        public static NameValueCollection Parse(string blob)
+        {
+            var result = new NameValueCollection();
+
+            foreach (Match line in Parser.Matches(blob))
+            {
+                var k = line.Groups[1].Value.Trim();
+                var v = line.Groups[2].Value.Trim();
+
+                result.Add(k, v);
+            }
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
Just sharing some code I had to cook up to do something similar. Might consider adapting it for use in this project (does not presently support colon delimiters).

Example (`example.env`):
````
title=Page Title
description=This is a description

setting1 = Testing whitespace in setting 1
setting2  = Testing whitespace in setting 2

setting3 =  Testing whitespace in setting 3



setting4= Testing whitespace in setting 4

# Testing comment
Testing invalid setting line
setting5 =Testing whitespace in setting 5

Testing invalid setting line with stray = sign
````

Result (`NameValueCollection`):
````
title: Page Title
description: This is a description
setting1: Testing whitespace in setting 1
setting2: Testing whitespace in setting 2
setting3: Testing whitespace in setting 3
setting4: Testing whitespace in setting 4
setting5: Testing whitespace in setting 5
````